### PR TITLE
Fix usage with workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ views to do so. For example with lualine:
 ```lua
 require('lualine').setup {
   winbar = {
-    lualine_a = { require("do").view },
+    lualine_a = {
+      function()
+        return require('do').view('active')
+      end,
+    },
   },
   inactive_winbar = {
     -- in order to prevent jumping of code in certain cursor positions this will

--- a/lua/do/core.lua
+++ b/lua/do/core.lua
@@ -136,6 +136,8 @@ function C.toggle_winbar()
 end
 
 function C.view(variant)
+  state.tasks = store.init(state.options.store)
+
   if variant == 'active' then
     return view.render(state)
   end
@@ -147,6 +149,8 @@ end
 
 ---for things like lualine
 function C.view_inactive()
+  state.tasks = store.init(state.options.store)
+
   return view.render_inactive(state)
 end
 


### PR DESCRIPTION
I found two things when using lualine with [workspaces.nvim](https://github.com/natecraddock/workspaces.nvim):
- When working with lualine, the example is incorrect as `view` requires the variant be passed or else it returns `nil`
- When using workspaces, because the store's `init` method only gets called on `setup`, if you open vim in one folder, and switch to another workspace, the new do.nvim tasks file won't reload

This PR updates the README to have a working `lualine` example, as well as fixes the issue with workspaces by reinstantiating the client on render