### PR TITLE
Fix missing tasks due to files being overwritten/not found

### DIFF
--- a/lua/do/store.lua
+++ b/lua/do/store.lua
@@ -14,6 +14,14 @@ local default_state = {
 
 function M:create_file()
   local name = self.options.file_name
+
+  if vim.uv.fs_stat(name) then
+    vim.notify(
+      "do.nvim: couldn't create. file already exists "..name,
+      vim.log.levels.WARN
+    )
+  end
+
   local f = io.open(name, "w")
   assert(f, "couldn't create " .. name)
   f:write("")

--- a/lua/do/store.lua
+++ b/lua/do/store.lua
@@ -24,13 +24,13 @@ end
 ---@param force? boolean force creation of file
 function M:find_file(force)
   local options = self.options
-  local file = vim.fn.findfile(options.file_name, ".;")
+  local match, file = next(vim.fs.find({options.file_name}, {upward=true, limit=1}))
 
-  if file == "" and force then
+  if match == nil and force then
     file = self:create_file()
   end
 
-  if file == "" then
+  if match == nil then
     return nil
   end
 


### PR DESCRIPTION
Currently the search moves from the active buffer upwards. If the location of cwd is below that buffer, do will not find that file. Additionally, if auto_create_file is enabled it will overwrite the existing file in cwd resulting in the loss of all previously defined tasks.

I changed the logic to use vim.fs.find instead of vim.fn.findfiles. vim.fs.find always starts at cwd as default. I also added a failsafe in the create_file logic, to double check if there is no file at the create location. If it finds one it will not create one and emit a notification with a warning level. 